### PR TITLE
Build fixes for Fedora

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(rqt_graphprofiler)
 
-find_package(catkin REQUIRED COMPONENTS
-#   message_generation
-  rospy
-  rqt_gui
-  rqt_gui_py
-  std_msgs
-)
+find_package(catkin REQUIRED)
 
 catkin_python_setup()
 

--- a/package.xml
+++ b/package.xml
@@ -26,6 +26,7 @@
   <run_depend>std_msgs</run_depend>
 
   <export>
+      <architecture_independent/>
       <rqt_gui plugin="${prefix}/plugin.xml"/>
   </export>
 </package>


### PR DESCRIPTION
First change exports `<architecture_independent/>` (see https://github.com/ros/rosdistro/issues/4037)

Second change removes the dependency on several components at build time. These aren't needed to run `catkin_python_setup()`.

Example break: http://csc.mcs.sdsmt.edu/jenkins/job/ros-indigo-rqt-graphprofiler_binaryrpm_heisenbug_x86_64/2/console
